### PR TITLE
Add distribution id when there's no process.env.DISTRIBUTION_ID

### DIFF
--- a/lib/Void.js
+++ b/lib/Void.js
@@ -92,7 +92,8 @@ class Void {
                 createTimeout  : this.createTimeout,
                 checkDelay     : this.checkDelay,
                 checkInterval  : this.checkInterval,
-                checkTimeout   : this.checkTimeout
+                checkTimeout   : this.checkTimeout,
+                distribution   : this.distribution,
             });
 
             this.queue.push(job);


### PR DESCRIPTION
It appears that the distribution id doesn't make it to the job right now. Fix inside.